### PR TITLE
Make check only run on `main` PRs.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Build zola website to ensure no errors
 on:
   pull_request:
     branch:
-      master
+      main
 
 jobs:
   build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,9 @@
 name: Build zola website to ensure no errors
 
 on:
-  pull_request
+  pull_request:
+    branch:
+      master
 
 jobs:
   build:
@@ -13,4 +15,4 @@ jobs:
       - name: build_and_deploy
         uses: shalzz/zola-deploy-action@v0.17.2
         env:
-          BUILD_ONLY=true
+          BUILD_ONLY: true


### PR DESCRIPTION
This is the first proper PR since branch protection was turned on. It will only run the workflow on a PR to master. I'm not 100% sure the syntax is correct so I would welcome someone else checking. It's not an important PR because there won't be any PRs against other branches, but it also tests the workflow for approving PRs.