### PR TITLE
docs: update crates

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -41,7 +41,9 @@ These crates are under active development.
 
 The following crates are not part of the `xilem`/`vello` stack, but are under active development.
 
- - [`velato`][velato] - A crate that renders Lottie animations to `vello`.
+ - [`velato`][velato] - A crate that converts Lottie animations to `vello` scenes for rendering.
+ - [`vello_svg`][vello_svg] - A crate that converts SVG documents to `vello` scenes for rendering.
+ - [`parley`][parley] - A crate for rich text layouts.
  - [`norad`][norad] - A crate for reading, writing, and manipulating [Unified Font Object] files, a common font-design format.
 
 ## Crates (passively maintained)
@@ -90,6 +92,8 @@ The following crates are not part of the `xilem`/`vello` stack, but are under ac
 [xilem]: https://github.com/linebender/xilem
 [2d.graphics]: https://github.com/linebender/2d.graphics
 [velato]: https://github.com/linebender/velato
+[vello_svg]: https://github.com/linebender/vello_svg
+[parley]: https://github.com/linebender/parley
 [norad]: https://github.com/linebender/norad
 [peniko]: https://github.com/linebender/peniko
 [druid-widget-nursery]: https://github.com/linebender/druid-widget-nursery

--- a/content/_index.md
+++ b/content/_index.md
@@ -39,12 +39,8 @@ These crates are under active development.
 
    This crate provides a set of shared types for concepts that are important for drawing/stroking paths, but excluding the path geometry itself (which can be found in [`kurbo`][kurbo]). It includes types for brush styles (including gradient) and color.
 
- - [`parley`][parley] - A library for rich text layouts.
-
-   This crate provides a set of shared types for concepts that are important for rendering text. It is backed by [`swash`][swash].
-
-The following crates are not part of the `xilem`/`vello` stack, but are under active development.
-
+ - [`parley`][parley] - A library for rich text layouts. It is backed by [`swash`][swash].
+ - [`fontique`][fontique] - A library for font enumeration and fallback library. Used by `parley`.
  - [`velato`][velato] - A crate that converts Lottie animations to `vello` scenes for rendering.
  - [`vello_svg`][vello_svg] - A crate that converts SVG documents to `vello` scenes for rendering.
  - [`norad`][norad] - A crate for reading, writing, and manipulating [Unified Font Object] files, a common font-design format.
@@ -97,6 +93,7 @@ The following crates are not part of the `xilem`/`vello` stack, but are under ac
 [velato]: https://github.com/linebender/velato
 [vello_svg]: https://github.com/linebender/vello_svg
 [parley]: https://github.com/linebender/parley
+[fontique]: https://github.com/linebender/parley/tree/main/fontique
 [swash]: https://github.com/dfrg/swash
 [norad]: https://github.com/linebender/norad
 [peniko]: https://github.com/linebender/peniko

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,7 +47,6 @@ The following crates are not part of the `xilem`/`vello` stack, but are under ac
 
  - [`velato`][velato] - A crate that converts Lottie animations to `vello` scenes for rendering.
  - [`vello_svg`][vello_svg] - A crate that converts SVG documents to `vello` scenes for rendering.
- - [`parley`][parley] - A crate for rich text layouts.
  - [`norad`][norad] - A crate for reading, writing, and manipulating [Unified Font Object] files, a common font-design format.
 
 ## Crates (passively maintained)

--- a/content/_index.md
+++ b/content/_index.md
@@ -39,8 +39,8 @@ These crates are under active development.
 
    This crate provides a set of shared types for concepts that are important for drawing/stroking paths, but excluding the path geometry itself (which can be found in [`kurbo`][kurbo]). It includes types for brush styles (including gradient) and color.
 
- - [`parley`][parley] - A library for rich text layouts. It is backed by [`swash`][swash].
- - [`fontique`][fontique] - A library for font enumeration and fallback library. Used by `parley`.
+ - [`parley`][parley] - A crate for rich text layouts. It is backed by [`swash`][swash].
+ - [`fontique`][fontique] - A crate for font enumeration and fallback. Used by `parley`.
  - [`velato`][velato] - A crate that converts Lottie animations to `vello` scenes for rendering.
  - [`vello_svg`][vello_svg] - A crate that converts SVG documents to `vello` scenes for rendering.
  - [`norad`][norad] - A crate for reading, writing, and manipulating [Unified Font Object] files, a common font-design format.

--- a/content/_index.md
+++ b/content/_index.md
@@ -39,6 +39,10 @@ These crates are under active development.
 
    This crate provides a set of shared types for concepts that are important for drawing/stroking paths, but excluding the path geometry itself (which can be found in [`kurbo`][kurbo]). It includes types for brush styles (including gradient) and color.
 
+ - [`parley`][parley] - A library for rich text layouts.
+
+   This crate provides a set of shared types for concepts that are important for rendering text. It is backed by [`swash`][swash].
+
 The following crates are not part of the `xilem`/`vello` stack, but are under active development.
 
  - [`velato`][velato] - A crate that converts Lottie animations to `vello` scenes for rendering.
@@ -94,6 +98,7 @@ The following crates are not part of the `xilem`/`vello` stack, but are under ac
 [velato]: https://github.com/linebender/velato
 [vello_svg]: https://github.com/linebender/vello_svg
 [parley]: https://github.com/linebender/parley
+[swash]: https://github.com/dfrg/swash
 [norad]: https://github.com/linebender/norad
 [peniko]: https://github.com/linebender/peniko
 [druid-widget-nursery]: https://github.com/linebender/druid-widget-nursery


### PR DESCRIPTION
Adds `vello_svg`, `velato`, and `parley`. Closes #43.

Note: Remove branch after merge.