### PR TITLE
Load polyfill.min.js from cdnjs

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,7 @@
         <link type="application/atom+xml" rel="alternate" href="/{{config.feed_filename}}" title="{{config.title}}">
         {% endif %}
     <!-- mathjax support -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
     <script>
         MathJax = {
           tex: {

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,6 @@
         <link type="application/atom+xml" rel="alternate" href="/{{config.feed_filename}}" title="{{config.title}}">
         {% endif %}
     <!-- mathjax support -->
-    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
     <script>
         MathJax = {
           tex: {


### PR DESCRIPTION
Resolves #65.

As mentioned in the above issue, polyfill.io is now being used to host a supply-chain attack. I've replaced the polyfill.io URL with [a replacement hosted on cdnjs](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk/).