### PR TITLE
Fix non-test lints applying to tests.

### DIFF
--- a/content/wiki/canonical_lints.md
+++ b/content/wiki/canonical_lints.md
@@ -75,14 +75,16 @@ clippy.wildcard_dependencies = "warn"
 ## `lib.rs`
 
 ```rust
-// LINEBENDER LINT SET - lib.rs - v2
+// LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/
-// These lints aren't included in Cargo.toml because they
-// shouldn't apply to examples and tests
-#![warn(unused_crate_dependencies)]
-#![warn(clippy::print_stdout, clippy::print_stderr)]
+// These lints aren't included in Cargo.toml because they shouldn't apply to examples and tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(not(test), warn(clippy::print_stderr, clippy::print_stdout))]
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
-#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
+#![cfg_attr(
+    all(not(test), target_pointer_width = "64"),
+    warn(clippy::trivially_copy_pass_by_ref)
+)]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 ```

--- a/content/wiki/canonical_lints.md
+++ b/content/wiki/canonical_lints.md
@@ -77,14 +77,12 @@ clippy.wildcard_dependencies = "warn"
 ```rust
 // LINEBENDER LINT SET - lib.rs - v3
 // See https://linebender.org/wiki/canonical-lints/
-// These lints aren't included in Cargo.toml because they shouldn't apply to examples and tests.
+// These lints shouldn't apply to examples or tests.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(not(test), warn(clippy::print_stderr, clippy::print_stdout))]
+// These lints shouldn't apply to examples.
+#![warn(clippy::print_stdout, clippy::print_stderr)]
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
-#![cfg_attr(
-    all(not(test), target_pointer_width = "64"),
-    warn(clippy::trivially_copy_pass_by_ref)
-)]
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 ```


### PR DESCRIPTION
The lints in `lib.rs` are not supposed to apply to tests according to the comment. This is a good idea, because there are a lot of false positives with tests. However the lint is still applied to tests.

Currently all the repos have ad hoc workarounds. See e.g. [Xilem](https://github.com/linebender/xilem/blob/363e4222c29cbddf174570af5d4a5b448d3fb73e/xilem/src/lib.rs#L14-L20), [Kurbo](https://github.com/linebender/kurbo/blob/8f074e921e3425b97c522fd38fb9593b0aef3aa4/src/svg.rs#L629-L635), and [Velato](https://github.com/linebender/velato/blob/2d6cd9516f93d662c6ea4096bbf837b8151dfc76/src/lib.rs#L74).

The solution is to actually only enable this lint when `test` isn't enabled.

Might as well do the same for `clippy::trivially_copy_pass_by_ref` as it's probably more annoying than valuable in tests.

I also moved the comment to a single line. It is a single sentence and under our 100 character line limit. Helps reduce the line count of the lint set.

I swapped the order to `clippy::print_stderr` and `clippy::print_stderr` so that they are alphabetically ordered, as is the case with our other lints.