### PR TITLE
Update project listing.

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -11,86 +11,118 @@ We hang out on the [Linebender Zulip][xi.zulip] and always welcome new people.
 
 # Linebender projects
 
-Below is a list of the main Linebender projects, and a short description of each project's purpose, as of 2024-07-23.
+Below is a list of the main Linebender projects, and a short description of each project's purpose, as of 2024-12-07.
 
 ## Crates (actively developed)
 
-These crates are under active development.
-
- - [`xilem`][xilem] - An experimental Rust architecture for reactive UI.
+ - [`xilem`][xilem] - Experimental Rust architecture for reactive UI.
 
    Xilem is a UI toolkit with a medium-grained reactive architecture strongly inspired by SwiftUI.
    It is currently in a pre-alpha state, with several significant issues, but is improving rapidly.
 
- - [`masonry`][masonry] - A foundational framework for Rust GUI libraries.
+ - [`masonry`][masonry] - Foundational framework for Rust GUI libraries.
 
-   Masonry is an evolution of Druid, designed to be driven by a higher-level UI toolkits.
-   It is currently used to power Xilem, but is designed to be usable by other libraries as well.
+   Masonry is an evolution of Druid, designed to be driven by higher-level UI toolkits.
+   It is currently used to power Xilem, but is designed to be usable by other toolkits as well.
 
- - [`vello`][vello] - An experimental GPU compute-centric 2D renderer.
+ - [`vello`][vello] - GPU compute-centric 2D renderer.
 
-   Vello is an experimental 2D graphics rendering engine written in Rust, with a focus on GPU compute.
+   Vello is a 2D graphics rendering engine written in Rust, with a focus on GPU compute.
    It can draw large 2D scenes with interactive or near-interactive performance, using [`wgpu`][wgpu] for GPU access.
 
- - [`kurbo`][kurbo] - A library for creating, manipulating and interrogating 2D curve shapes.
+ - [`kurbo`][kurbo] - Create, manipulate, and interrogate 2D curve shapes.
 
-   At its core, `kurbo` is a library for constructing paths and splines out of straight lines and Bézier curves up to order 3 (known as cubic Béziers). It turns out that a series of cubic Bézier curves can be used to approximate any smooth curve with a very high degree of accuracy, compared to the number of curves required. They are also relatively easy to work with, and form the basis of the approach to curve rendering used in `vello`. The key abstraction is [`kurbo::Shape`](https://docs.rs/kurbo/latest/kurbo/trait.Shape.html), which provides the `path_elements` method. This method returns an iterator over Bézier curves that approximate the type implementing the `Shape` trait, which `vello` can then draw.
+   At its core, Kurbo is a library for constructing paths and splines out of straight lines and Bézier curves up to order 3 (known as cubic Béziers).
+   It turns out that a series of cubic Bézier curves can be used to approximate any smooth curve with a very high degree of accuracy, compared to the number of curves required.
+   They are also relatively easy to work with, and form the basis of the approach to curve rendering used in Vello.
+   The key abstraction is [`kurbo::Shape`](https://docs.rs/kurbo/latest/kurbo/trait.Shape.html), which provides the `path_elements` method.
+   This method returns an iterator over Bézier curves that approximate the type implementing the `Shape` trait, which Vello can then draw.
 
- - [`peniko`][peniko] - A library for non-geometric drawing primitives.
+ - [`color`][color] - Manipulate and represent colors.
 
-   This crate provides a set of shared types for concepts that are important for drawing/stroking paths, but excluding the path geometry itself (which can be found in [`kurbo`][kurbo]). It includes types for brush styles (including gradient) and color.
+   Color provides functionality for representing, converting, parsing, serializing, and manipulating colors in a variety of color spaces.
+   It closely follows the [CSS Color Level 4] draft spec.
 
- - [`parley`][parley] - A crate for rich text layouts. It is backed by [`swash`][swash].
- - [`fontique`][fontique] - A crate for font enumeration and fallback. Used by `parley`.
- - [`velato`][velato] - A crate that converts Lottie animations to `vello` scenes for rendering.
- - [`vello_svg`][vello_svg] - A crate that converts SVG documents to `vello` scenes for rendering.
- - [`norad`][norad] - A crate for reading, writing, and manipulating [Unified Font Object] files, a common font-design format.
+ - [`peniko`][peniko] - Non-geometric drawing primitives.
+
+   Provides a set of shared types for concepts that are important for drawing/stroking paths, but excluding the path geometry itself (which can be found in [`kurbo`][kurbo]).
+   It includes types for brush styles (including gradient) and color.
+
+ - [`parley`][parley] - Rich text layout, backed by [`swash`][swash].
+ - [`fontique`][fontique] - Font enumeration and fallback.
+ - [`velato`][velato] - Convert Lottie animations to Vello scenes for rendering.
+ - [`vello_svg`][vello_svg] - Convert SVG documents to Vello scenes for rendering.
+ - [`interpoli`][interpoli] - Functionality for animating values.
+ - [`kompari`][kompari] - A tool for detecting and reporting differences in images.
+ - [`norad`][norad] - Read, write, and manipulate [Unified Font Object] files, a common font-design format.
 
 ## Crates (passively maintained)
 
- - [`druid`][druid] - A GUI framework for Rust.
+ - [`druid`][druid] - GUI framework for Rust.
 
-   `druid` is the original Linebender UI framework, and was the main focus of development until early 2023. There are many good things about `druid`, but the data model it uses (primarily `Lens`es) gets complicated in Rust, and doesn't compose as well as it would in a [GC'd][garbage collection] functional programming language. However, a lot of the things that work will be copied straight over to `xilem`, and today `druid` is a solid choice for a new UI app projected to have low to medium complexity. The [#druid-help channel on Zulip](https://xi.zulipchat.com/#narrow/stream/255910-druid-help) is still monitored and you will likely get good answers to any questions you have.
+   Druid was the original Linebender UI framework, and was the main focus of development until early 2023.
+   New development effort has moved on to [Xilem][xilem], which is quite different, but still heavily inherits from Druid via [Masonry][masonry].
 
- - [`piet`][piet] - An abstraction layer over platform 2D rendering facilities.
+   Druid's main goal was to offer a polished user experience.
+   There were many factors to this goal, including performance, a rich palette of interactions, and playing well with the native platform.
+   
+   Druid is reasonably usable for [some subset of applications](https://github.com/linebender/druid/issues/1360) and has a significant testing history, which ensures some stability and correctness.
+   However, there will not be any new features or bug fixes coming to Druid.
+   As such we don't recommend using Druid for brand new applications.
+   If you insist, then at least make sure your application doesn't require a feature that Druid doesn't have, e.g. accessibility or 3D support.
 
-   The purpose of the `piet` library is to provide abstraction over the libraries used for 2D rendering on any particular platform ([Direct2D] on Windows, [Core Graphics] on Mac, and [cairo]/[pango] on Linux). The goal is for `piet` to be superseded by the `vello` crate, which will provide state-of-the-art 2D rendering on any platform supported by [WebGPU].
+ - [`piet`][piet] - Abstraction layer over platform 2D rendering facilities.
 
- - [`druid-shell`][druid-shell] - The windowing library for `druid`.
+   It provides an abstraction over the libraries used for 2D rendering on any particular platform ([Direct2D] on Windows, [Core Graphics] on Mac, and [Cairo]/[Pango] on Linux).
 
-   It lives in the `druid` repository. When our focus moved over to `vello`/`xilem`, there was debate over whether to split this code into its own crate, or move over to `winit`. We decided to keep using our own windowing library for now, to give us the flexibility to add or change what we need to. Thus `glazier` was born as a fork of `druid-shell`.
+   Our goal is for Piet to be superseded by Vello, which will provide state-of-the-art GPU accelerated 2D rendering on any platform supported by [WebGPU].
 
- - [`druid-widget-nursery`][druid-widget-nursery] - A crate with widgets for `druid`.
+ - [`druid-shell`][druid-shell] - The windowing library for Druid.
 
-   This crate contains lots of `druid` widgets that may be useful to UI developers. It includes things like widgets for [Material Icons], and a tree view (a way to draw data stored in a tree). It followed the very liberal [optimistic merging] strategy for handling PRs to minimize contributor friction, but the widgets contributed are all robust and high quality.
+   It was created due to limitations with [`winit`][winit] and has features like file dialogs, system menus, and modal windows.
+   When we started work on Xilem, we also forked `druid-shell` to bootstrap [Glazier][glazier].
 
- - [`runebender`][runebender] - An experimental font editor.
+ - [`druid-widget-nursery`][druid-widget-nursery] - Experimental widgets for Druid.
 
-   This was the motivating application for `druid` development. It is not currently seeing active development, but this may be revisited in the future.
+   Contains lots of Druid widgets that may be useful to UI developers.
+   For example a widget to draw [Material Icons], a tree view, and a dropdown.
+   It followed the very liberal [optimistic merging] strategy for handling PRs to minimize contributor friction, but the widgets contributed are all robust and high quality.
 
- - [`skribo`][skribo] - A library for text layout.
+ - [`runebender`][runebender] - Experimental font editor.
 
-   This library aims to perform the conversion from text and font attributes to glyph runs, similar to [harfbuzz]. It's not recommended to use this library as better alternatives exist, for example [`parley`] or [`cosmic-text`].
+   This was the motivating application for Druid development.
+   It is not currently seeing active development, but this may be revisited in the future.
+
+ - [`skribo`][skribo] - Text layout.
+
+   This library aims to perform the conversion from text and font attributes to glyph runs, similar to [harfbuzz].
+   It's not recommended to use this library as better alternatives exist, for example [`parley`] or [`cosmic-text`].
 
 ## Non-code repos
 
  - [`2d.graphics`][2d.graphics] - A work-in-progress book explaining the current state of the art of different aspects of 2D graphics.
 
-   Currently the book mostly contains annotated reference lists, although some sections have written content. Pull requests welcome! The goal is to cover topics like color, shapes/curves, 2D GPU rendering, text, etc.
+   Currently the book mostly contains annotated reference lists, although some sections have written content.
+   Pull requests welcome!
+   The goal is to cover topics like color, shapes/curves, 2D GPU rendering, text, etc.
 
- - [`linebender.github.io`][linebender.github.io] - This website. If you see anything that looks incorrect, please submit a PR to [the repo][linebender.github.io].
+ - [`linebender.github.io`][linebender.github.io] - This website.
+ 
+   If you see anything that looks incorrect, please submit a PR to [its repo][linebender.github.io].
 
-## Archived projects
+## Archived repos
 
- - [`glazier`][glazier] - A windowing library.
+ - [`glazier`][glazier] - Windowing library.
 
-   Glazier was created due to limitations with [`winit`][winit], however we have since decided to work together with the `winit` team to resolve those issues.
-   We now recommend the use of `winit` over Glazier.
+   Glazier was a fork of [`druid-shell`][druid-shell].
+   We pursued this due to limitations with [`winit`][winit], however eventually decided to work together with the `winit` team to improve `winit` instead.
+   We recommend using `winit` over Glazier.
 
 [xi.zulip]: https://xi.zulipchat.com
 [rust]: https://rust-lang.org
 [piet]: https://github.com/linebender/piet
 [kurbo]: https://github.com/linebender/kurbo
+[color]: https://github.com/linebender/color
 [druid]: https://github.com/linebender/druid
 [druid-shell]: https://github.com/linebender/druid/tree/master/druid-shell
 [glazier]: https://github.com/linebender/glazier
@@ -102,6 +134,8 @@ These crates are under active development.
 [2d.graphics]: https://github.com/linebender/2d.graphics
 [velato]: https://github.com/linebender/velato
 [vello_svg]: https://github.com/linebender/vello_svg
+[interpoli]: https://github.com/linebender/interpoli
+[kompari]: https://github.com/linebender/kompari
 [parley]: https://github.com/linebender/parley
 [fontique]: https://github.com/linebender/parley/tree/main/fontique
 [swash]: https://github.com/dfrg/swash
@@ -111,11 +145,10 @@ These crates are under active development.
 [skribo]: https://github.com/linebender/skribo
 [Unified Font Object]: http://unifiedfontobject.org/
 [winit]: https://github.com/rust-windowing/winit
-[garbage collection]: https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)
 [Direct2D]: https://learn.microsoft.com/en-us/windows/win32/direct2d/direct2d-portal
 [Core Graphics]: https://developer.apple.com/documentation/coregraphics
-[cairo]: https://www.cairographics.org/
-[pango]: https://pango.gnome.org/
+[Cairo]: https://www.cairographics.org/
+[Pango]: https://www.pango.org/
 [WebGPU]: https://www.w3.org/TR/webgpu/#intro
 [Material Icons]: https://fonts.google.com/icons
 [optimistic merging]: http://hintjens.com/blog:106
@@ -123,3 +156,4 @@ These crates are under active development.
 [`parley`]: https://github.com/dfrg/parley
 [`cosmic-text`]: https://github.com/pop-os/cosmic-text
 [linebender.github.io]: https://github.com/linebender/linebender.github.io
+[CSS Color Level 4]: https://www.w3.org/TR/css-color-4/


### PR DESCRIPTION
* Added `color`, `interpoli`, `kompari`.
* Simplified language, e.g. removed the *A crate for* prefixes as the heading already stated these are crates.
* Updated the descriptions for Druid and its associates.
* One line per sentence.