### PR TITLE
Make `clippy::shadow_unrelated` a periodical lint

### DIFF
--- a/content/wiki/canonical_lints.md
+++ b/content/wiki/canonical_lints.md
@@ -45,7 +45,6 @@ clippy.missing_assert_message = "warn"
 clippy.missing_fields_in_debug = "warn"
 clippy.same_functions_in_if_condition = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
-clippy.shadow_unrelated = "warn"
 clippy.should_panic_without_expect = "warn"
 clippy.todo = "warn"
 clippy.unseparated_literal_suffix = "warn"
@@ -115,12 +114,13 @@ clippy::match_same_arms
 clippy::partial_pub_fields
 clippy::default_trait_access
 clippy::return_self_not_must_use
+clippy::shadow_unrelated
 ```
 
 As a runnable command, there are:
 
 ```sh
-cargo clippy -- -W let_underscore_drop -W single_use_lifetimes -W unit_bindings -W unused_qualifications -W variant_size_differences -W clippy::large_include_file -W clippy::match_same_arms -W clippy::partial_pub_fields -W clippy::default_trait_access -W clippy::return_self_not_must_use
+cargo clippy -- -W let_underscore_drop -W single_use_lifetimes -W unit_bindings -W unused_qualifications -W variant_size_differences -W clippy::large_include_file -W clippy::match_same_arms -W clippy::partial_pub_fields -W clippy::default_trait_access -W clippy::return_self_not_must_use -W clippy::shadow_unrelated
 ```
 
 You may also wish to enable some of these lints specifically in your editor, to improve as you go.

--- a/content/wiki/canonical_lints.md
+++ b/content/wiki/canonical_lints.md
@@ -11,7 +11,7 @@ All Linebender projects should include the following set of lints:
 # This one may vary depending on the project.
 rust.unsafe_code = "forbid"
 
-# LINEBENDER LINT SET - Cargo.toml - v5
+# LINEBENDER LINT SET - Cargo.toml - v6
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"
 rust.non_ascii_idents = "forbid"


### PR DESCRIPTION
This is quite unfortunate, because this lint can be useful. It can however be a bit of a drag in test code (although I'd argue that it also improves that)

The reason I'm suggesting removing it from the default set entirely is:
1) It really breaks with Xilem, because of e.g. `button`
2) It's a little-bit over-eager sometimes (e.g. https://github.com/linebender/vello/blob/782fb5a3ea8dc06bac614790131c2695802766ae/examples/scenes/src/simple_text.rs#L222)

However, it does still raise things which should be fixed (e.g. https://github.com/linebender/vello/blob/782fb5a3ea8dc06bac614790131c2695802766ae/examples/scenes/src/mmark.rs#L90) so we should still run it.