### PR TITLE
Remove `unexpected_cfgs` from the lint set

### DIFF
--- a/content/wiki/canonical_lints.md
+++ b/content/wiki/canonical_lints.md
@@ -11,7 +11,7 @@ All Linebender projects should include the following set of lints:
 # This one may vary depending on the project.
 rust.unsafe_code = "forbid"
 
-# LINEBENDER LINT SET - Cargo.toml - v6
+# LINEBENDER LINT SET - Cargo.toml - v6.1
 # See https://linebender.org/wiki/canonical-lints/
 rust.keyword_idents_2024 = "forbid"
 rust.non_ascii_idents = "forbid"
@@ -22,7 +22,6 @@ rust.elided_lifetimes_in_paths = "warn"
 rust.missing_debug_implementations = "warn"
 rust.missing_docs = "warn"
 rust.trivial_numeric_casts = "warn"
-rust.unexpected_cfgs = "warn"
 rust.unnameable_types = "warn"
 rust.unreachable_pub = "warn"
 rust.unused_import_braces = "warn"


### PR DESCRIPTION
This is a fully backwards-compatible change, because `unexpected_cfgs` is already warn by default

Going through the history, this was added to the lint set because:
- Xilem set the lint explicitly to support the cfgs it needed (FALSE and tarpaulin)
- https://github.com/linebender/peniko/pull/47 copied the lints from Xilem, even though it didn't need to configure unexpected_cfgs
- The original lint set PR was based on the set in Peniko

I've treated this as v6.1 due to the backwards compatibility. We can make the next change be v7.0 or just v7 again.