### PR TITLE
A few updates to the lint set

### DIFF
--- a/content/wiki/canonical_lints.md
+++ b/content/wiki/canonical_lints.md
@@ -122,16 +122,6 @@ As a runnable command, there are:
 cargo clippy -- -W let_underscore_drop -W single_use_lifetimes -W unit_bindings -W variant_size_differences -W clippy::large_include_file -W clippy::match_same_arms -W clippy::partial_pub_fields -W clippy::return_self_not_must_use -W clippy::shadow_unrelated
 ```
 
-You may also wish to enable some of these lints specifically in your editor, to improve as you go.
-The ones which are trivial to do this for are below (as the changes it will propose are always very small):
-
-```sh
-cargo clippy -- -W single_use_lifetimes -W unit_bindings -W clippy::allow_attributes
-```
-
-If there are many failures of one of these lints across the project, a separate PR would be recommended.
-Otherwise, resolving these in a drive-by manner is fine.
-
 ### Pedantic
 
 You may occasionally want to run `cargo clippy` with `clippy::pedantic` on the codebase, which will cast a very wide net and catch a lot of very minor issues.


### PR DESCRIPTION
Having used [`clippy::default_trait_access`](https://rust-lang.github.io/rust-clippy/stable/index.html#default_trait_access) as an editor lint, I'm really happy with it. It also only ever makes extremely local suggestions (making addressing it when writing a change trivial), and significantly improves readability in a lot of cases. It's also something which I've now found myself suggesting regularly in PR reviews, as better style.
As such, I'm proposing that we move this into the proper lint set.

Separately, [`unused_qualifications`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-qualifications) is good for consistency (if you see `Rect` and `kurbo::Rect` next to each other, you might reasonably assume that they are different types). As such, I'm also proposing that we move this into the "proper" lint set out of the periodic lints.
This proposal is more marginal, and I'm happy to demote it back to a periodic lint if there's pushback.

Thirdly, I'm proposing removed the editor lints as a class; I don't think anyone ever used them, and the theory that you can make drive-by style fixes in otherwise unrelated PRs was never sound.